### PR TITLE
img.onload fix issues with img.width = 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,36 +1,38 @@
- resizebase64 = function(base64, maxWidth, maxHeight){
+resizebase64 = function(base64, maxWidth, maxHeight){
+ return new Promise((resolve, reject) => {
+        // Max size for thumbnail
+        if(typeof(maxWidth) === 'undefined')  maxWidth = 500;
+        if(typeof(maxHeight) === 'undefined')  maxHeight = 500;
 
+        // Create and initialize two canvas
+        var canvas = document.createElement("canvas");
+        var ctx = canvas.getContext("2d");
+        var canvasCopy = document.createElement("canvas");
+        var copyContext = canvasCopy.getContext("2d");
 
-// Max size for thumbnail
-  if(typeof(maxWidth) === 'undefined')  maxWidth = 500;
-  if(typeof(maxHeight) === 'undefined')  maxHeight = 500;
+        // Create original image
+        var img = new Image();
 
-  // Create and initialize two canvas
-  var canvas = document.createElement("canvas");
-  var ctx = canvas.getContext("2d");
-  var canvasCopy = document.createElement("canvas");
-  var copyContext = canvasCopy.getContext("2d");
+        img.onload = () => {
+          // Determine new ratio based on max size
+          var ratio = 1;
+          if(img.width > maxWidth)
+            ratio = maxWidth / img.width;
+          else if(img.height > maxHeight)
+            ratio = maxHeight / img.height;
 
-  // Create original image
-  var img = new Image();
-  img.src = base64;
+          // Draw original image in second canvas
+          canvasCopy.width = img.width;
+          canvasCopy.height = img.height;
+          copyContext.drawImage(img, 0, 0);
 
-  // Determine new ratio based on max size
-  var ratio = 1;
-  if(img.width > maxWidth)
-    ratio = maxWidth / img.width;
-  else if(img.height > maxHeight)
-    ratio = maxHeight / img.height;
+          // Copy and resize second canvas to first canvas
+          canvas.width = img.width * ratio;
+          canvas.height = img.height * ratio;
+          ctx.drawImage(canvasCopy, 0, 0, canvasCopy.width, canvasCopy.height, 0, 0, canvas.width, canvas.height);
 
-  // Draw original image in second canvas
-  canvasCopy.width = img.width;
-  canvasCopy.height = img.height;
-  copyContext.drawImage(img, 0, 0);
-
-  // Copy and resize second canvas to first canvas
-  canvas.width = img.width * ratio;
-  canvas.height = img.height * ratio;
-  ctx.drawImage(canvasCopy, 0, 0, canvasCopy.width, canvasCopy.height, 0, 0, canvas.width, canvas.height);
-
-  return canvas.toDataURL();
+          resolve(canvas.toDataURL());
+        }
+        img.src = base64;
+      });
 }


### PR DESCRIPTION
Fixed the issue of: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The image argument is a canvas element with a width or height of 0. #1.

Had to return promise to comply with asynchronous onload. Could've been made synchronous by following this example: https://www.gamedev.net/forums/topic/650999-synchronous-loading-of-images-in-html5/

Please test, as I've just tested inside my application as a function and worked fine for me, copied in the Github editor and done this PR.